### PR TITLE
docs: removed StartActivity command from C# example

### DIFF
--- a/packages/appium/docs/en/quickstart/test-dotnet.md
+++ b/packages/appium/docs/en/quickstart/test-dotnet.md
@@ -63,7 +63,6 @@ public class Tests
     [Test]
     public void TestFindApps()
     {
-        _driver.StartActivity("com.android.settings", ".Settings");
         _driver.FindElement(By.XPath("//*[@text='Apps']")).Click();
     }
 }


### PR DESCRIPTION
StartActivity isn't using in Appium v8.
After setup Appium from NuGet package I tried to use example for C# and can't build the project. I suppose StartActivity has been changed. So I try to delete this and run in Appium v8. After deleted string with this command, project sucessfully build and run.

Documentation for C# where have mistake:
https://appium.io/docs/en/latest/quickstart/test-dotnet/